### PR TITLE
Fix/sonarcloud issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ __pycache__/
 htmlcov/
 github_project/
 exemplos/data/
+
+.cloude/

--- a/sonar_github_issues.py
+++ b/sonar_github_issues.py
@@ -1,10 +1,12 @@
 import os
+from datetime import datetime
 
 import requests
 
 # =========================
 # CONFIG
 # =========================
+
 SONAR_TOKEN = os.getenv("SONAR_TOKEN")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
@@ -15,11 +17,32 @@ GITHUB_REPO = "Cristiano2132/model-track-cr"
 SONAR_URL = "https://sonarcloud.io/api/issues/search"
 GITHUB_URL = f"https://api.github.com/repos/{GITHUB_REPO}/issues"
 
+EXPORT_FILE = "sonar_issues.md"
+
+SONAR_URL = "https://sonarcloud.io/api/issues/search"
+SONAR_AUTH_URL = "https://sonarcloud.io/api/authentication/validate"
+
+GITHUB_URL = f"https://api.github.com/repos/{GITHUB_REPO}/issues"
+
 sonar_auth = (SONAR_TOKEN, "")
 github_headers = {
     "Authorization": f"Bearer {GITHUB_TOKEN}",
     "Accept": "application/vnd.github+json",
 }
+
+
+# =========================
+# CHECK SONAR CONNECTION
+# =========================
+def check_sonar_connection():
+    print("🔐 Checking SonarCloud connection...")
+
+    response = requests.get(SONAR_AUTH_URL, auth=sonar_auth)
+
+    if response.status_code != 200 or not response.json().get("valid"):
+        raise Exception("❌ SonarCloud authentication failed")
+
+    print("✅ SonarCloud authentication successful")
 
 
 # =========================
@@ -50,6 +73,39 @@ def get_all_issues():
         page += 1
 
     return issues
+
+
+# =========================
+# EXPORT TO MARKDOWN
+# =========================
+def export_issues_to_markdown(issues):
+    print(f"📝 Exporting issues to {EXPORT_FILE}...")
+
+    with open(EXPORT_FILE, "w", encoding="utf-8") as f:
+        f.write("# SonarCloud Issues Export\n\n")
+        f.write(f"Project: `{SONAR_PROJECT_KEY}`\n")
+        f.write(f"Generated at: {datetime.utcnow()} UTC\n\n")
+        f.write(f"Total issues: **{len(issues)}**\n\n---\n\n")
+
+        for issue in issues:
+            f.write(f"## [{issue['severity']}] {issue['message']}\n\n")
+
+            f.write(f"- **Type:** {issue['type']}\n")
+            f.write(f"- **Rule:** {issue['rule']}\n")
+            f.write(f"- **File:** `{issue['component']}`\n")
+            f.write(f"- **Line:** {issue.get('line', 'N/A')}\n")
+            f.write(f"- **Effort:** {issue.get('effort', 'N/A')}\n")
+
+            if issue.get("tags"):
+                f.write(f"- **Tags:** {', '.join(issue['tags'])}\n")
+
+            f.write(
+                f"- **Link:** https://sonarcloud.io/project/issues?id={SONAR_PROJECT_KEY}&open={issue['key']}\n\n"
+            )
+
+            f.write("---\n\n")
+
+    print("✅ Export completed")
 
 
 # =========================
@@ -87,7 +143,7 @@ def build_title(issue):
 
 
 # =========================
-# BUILD BODY (PROFESSIONAL)
+# BUILD BODY
 # =========================
 def build_body(issue):
     return f"""
@@ -133,12 +189,7 @@ _This issue was automatically created from SonarCloud._
 # LABELS
 # =========================
 def build_labels(issue):
-    labels = ["sonarcloud"]
-
-    labels.append(issue["severity"].lower())
-    labels.append(issue["type"].lower())
-
-    return labels
+    return ["sonarcloud", issue["severity"].lower(), issue["type"].lower()]
 
 
 # =========================
@@ -160,24 +211,28 @@ def create_issue(title, body, labels):
 # MAIN
 # =========================
 def main():
+    check_sonar_connection()
+
     print("🔍 Fetching SonarCloud issues...")
     issues = get_all_issues()
 
     print(f"Total issues fetched: {len(issues)}")
 
-    existing_titles = get_existing_titles()
+    export_issues_to_markdown(issues)
 
-    for issue in issues:
-        title = build_title(issue)
+    # existing_titles = get_existing_titles()
 
-        if title in existing_titles:
-            print(f"⏭️ Skipping: {title}")
-            continue
+    # for issue in issues:
+    #     title = build_title(issue)
 
-        body = build_body(issue)
-        labels = build_labels(issue)
+    #     if title in existing_titles:
+    #         print(f"⏭️ Skipping: {title}")
+    #         continue
 
-        create_issue(title, body, labels)
+    #     body = build_body(issue)
+    #     labels = build_labels(issue)
+
+    #     create_issue(title, body, labels)
 
 
 if __name__ == "__main__":

--- a/sonar_github_issues.py
+++ b/sonar_github_issues.py
@@ -1,0 +1,184 @@
+import os
+
+import requests
+
+# =========================
+# CONFIG
+# =========================
+SONAR_TOKEN = os.getenv("SONAR_TOKEN")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+
+SONAR_PROJECT_KEY = "Cristiano2132_model-track-cr"
+GITHUB_REPO = "Cristiano2132/model-track-cr"
+
+
+SONAR_URL = "https://sonarcloud.io/api/issues/search"
+GITHUB_URL = f"https://api.github.com/repos/{GITHUB_REPO}/issues"
+
+sonar_auth = (SONAR_TOKEN, "")
+github_headers = {
+    "Authorization": f"Bearer {GITHUB_TOKEN}",
+    "Accept": "application/vnd.github+json",
+}
+
+
+# =========================
+# FETCH ALL ISSUES
+# =========================
+def get_all_issues():
+    issues = []
+    page = 1
+
+    while True:
+        params = {
+            "projectKeys": SONAR_PROJECT_KEY,
+            "ps": 100,
+            "p": page,
+            "statuses": "OPEN,CONFIRMED,REOPENED",
+            "types": "BUG,VULNERABILITY,CODE_SMELL",
+        }
+
+        response = requests.get(SONAR_URL, params=params, auth=sonar_auth)
+        response.raise_for_status()
+
+        data = response.json()
+        issues.extend(data["issues"])
+
+        if page * 100 >= data["total"]:
+            break
+
+        page += 1
+
+    return issues
+
+
+# =========================
+# EXISTING ISSUES
+# =========================
+def get_existing_titles():
+    titles = set()
+    page = 1
+
+    while True:
+        response = requests.get(
+            GITHUB_URL,
+            headers=github_headers,
+            params={"state": "open", "per_page": 100, "page": page},
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        if not data:
+            break
+
+        for issue in data:
+            titles.add(issue["title"])
+
+        page += 1
+
+    return titles
+
+
+# =========================
+# BUILD TITLE
+# =========================
+def build_title(issue):
+    return f"[SonarCloud][{issue['severity']}] {issue['message'][:80]}"
+
+
+# =========================
+# BUILD BODY (PROFESSIONAL)
+# =========================
+def build_body(issue):
+    return f"""
+## 🧪 SonarCloud Issue
+
+**Type:** {issue["type"]}  
+**Severity:** {issue["severity"]}  
+**Rule:** {issue["rule"]}  
+
+---
+
+### 📍 Location
+- **File:** `{issue["component"]}`
+- **Line:** {issue.get("line", "N/A")}
+
+---
+
+### 📝 Description
+{issue["message"]}
+
+---
+
+### 🔗 SonarCloud Link
+https://sonarcloud.io/project/issues?id={SONAR_PROJECT_KEY}&open={issue["key"]}
+
+---
+
+### ⚙️ Effort
+{issue.get("effort", "N/A")}
+
+---
+
+### 🏷️ Tags
+{", ".join(issue.get("tags", []))}
+
+---
+
+_This issue was automatically created from SonarCloud._
+"""
+
+
+# =========================
+# LABELS
+# =========================
+def build_labels(issue):
+    labels = ["sonarcloud"]
+
+    labels.append(issue["severity"].lower())
+    labels.append(issue["type"].lower())
+
+    return labels
+
+
+# =========================
+# CREATE ISSUE
+# =========================
+def create_issue(title, body, labels):
+    payload = {"title": title, "body": body, "labels": labels}
+
+    response = requests.post(GITHUB_URL, headers=github_headers, json=payload)
+
+    if response.status_code == 201:
+        print(f"✅ Created: {title}")
+    else:
+        print(f"❌ Failed: {title}")
+        print(response.text)
+
+
+# =========================
+# MAIN
+# =========================
+def main():
+    print("🔍 Fetching SonarCloud issues...")
+    issues = get_all_issues()
+
+    print(f"Total issues fetched: {len(issues)}")
+
+    existing_titles = get_existing_titles()
+
+    for issue in issues:
+        title = build_title(issue)
+
+        if title in existing_titles:
+            print(f"⏭️ Skipping: {title}")
+            continue
+
+        body = build_body(issue)
+        labels = build_labels(issue)
+
+        create_issue(title, body, labels)
+
+
+if __name__ == "__main__":
+    main()

--- a/sonar_issues.md
+++ b/sonar_issues.md
@@ -1,0 +1,189 @@
+# SonarCloud Issues Export
+
+Project: `Cristiano2132_model-track-cr`
+Generated at: 2026-04-17 03:10:38.067624 UTC
+
+Total issues: **15**
+
+---
+
+## [CRITICAL] Remove parameter column or provide default value.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S2638
+- **File:** `Cristiano2132_model-track-cr:src/model_track/binning/tree_binner.py`
+- **Line:** 19
+- **Effort:** 15min
+- **Tags:** suspicious
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_cHI4dBuagc4RC1
+
+---
+
+## [MAJOR] Add the missing hyperparameter ccp_alpha for this Scikit-learn estimator.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S6973
+- **File:** `Cristiano2132_model-track-cr:src/model_track/binning/tree_binner.py`
+- **Line:** 27
+- **Effort:** 5min
+- **Tags:** machine-learning, pytorch, scikit-learn
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_cHI4dBuagc4RC2
+
+---
+
+## [MAJOR] Provide a seed for the random_state parameter.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S6709
+- **File:** `Cristiano2132_model-track-cr:src/model_track/binning/tree_binner.py`
+- **Line:** 27
+- **Effort:** 5min
+- **Tags:** data-science, numpy, scientific-computing
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_cHI4dBuagc4RC3
+
+---
+
+## [CRITICAL] Remove parameter column or provide default value.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S2638
+- **File:** `Cristiano2132_model-track-cr:src/model_track/binning/tree_binner.py`
+- **Line:** 38
+- **Effort:** 15min
+- **Tags:** suspicious
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_cHI4dBuagc4RC4
+
+---
+
+## [CRITICAL] Refactor this function to reduce its Cognitive Complexity from 16 to the 15 allowed.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S3776
+- **File:** `Cristiano2132_model-track-cr:src/model_track/preprocessing/auditor.py`
+- **Line:** 50
+- **Effort:** 6min
+- **Tags:** brain-overload
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_bsI4dBuagc4RCx
+
+---
+
+## [CRITICAL] Refactor this function to reduce its Cognitive Complexity from 28 to the 15 allowed.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S3776
+- **File:** `Cristiano2132_model-track-cr:src/model_track/preprocessing/memory.py`
+- **Line:** 9
+- **Effort:** 18min
+- **Tags:** brain-overload
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_b0I4dBuagc4RCy
+
+---
+
+## [MINOR] Use `startswith` here.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S6659
+- **File:** `Cristiano2132_model-track-cr:src/model_track/preprocessing/memory.py`
+- **Line:** 25
+- **Effort:** 5min
+- **Tags:** convention, pep
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_b0I4dBuagc4RCz
+
+---
+
+## [CRITICAL] Refactor this function to reduce its Cognitive Complexity from 22 to the 15 allowed.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S3776
+- **File:** `Cristiano2132_model-track-cr:src/model_track/preprocessing/types.py`
+- **Line:** 19
+- **Effort:** 12min
+- **Tags:** brain-overload
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_b-I4dBuagc4RC0
+
+---
+
+## [MAJOR] Do not use "DataFrame.values".
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S6741
+- **File:** `Cristiano2132_model-track-cr:src/model_track/stats/metrics.py`
+- **Line:** 26
+- **Effort:** 5min
+- **Tags:** data-science, numpy, pandas
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_cXI4dBuagc4RC6
+
+---
+
+## [CRITICAL] Remove parameter features or provide default value.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S2638
+- **File:** `Cristiano2132_model-track-cr:src/model_track/stats/selection.py`
+- **Line:** 26
+- **Effort:** 15min
+- **Tags:** suspicious
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_cQI4dBuagc4RC5
+
+---
+
+## [CRITICAL] Remove parameter columns or provide default value.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S2638
+- **File:** `Cristiano2132_model-track-cr:src/model_track/woe/calculator.py`
+- **Line:** 25
+- **Effort:** 15min
+- **Tags:** suspicious
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_coI4dBuagc4RC9
+
+---
+
+## [CRITICAL] Remove parameter columns or provide default value.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S2638
+- **File:** `Cristiano2132_model-track-cr:src/model_track/woe/calculator.py`
+- **Line:** 36
+- **Effort:** 15min
+- **Tags:** suspicious
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_coI4dBuagc4RC-
+
+---
+
+## [MINOR] Replace the unused local variable "fig" with "_".
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S1481
+- **File:** `Cristiano2132_model-track-cr:src/model_track/woe/stability.py`
+- **Line:** 41
+- **Effort:** 5min
+- **Tags:** unused
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_cfI4dBuagc4RC7
+
+---
+
+## [CRITICAL] Refactor this function to reduce its Cognitive Complexity from 101 to the 15 allowed.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S3776
+- **File:** `Cristiano2132_model-track-cr:src/model_track/woe/stability.py`
+- **Line:** 74
+- **Effort:** 1h31min
+- **Tags:** brain-overload
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_cfI4dBuagc4RC8
+
+---
+
+## [MAJOR] Replace this expression; its boolean value is constant.
+
+- **Type:** CODE_SMELL
+- **Rule:** python:S5914
+- **File:** `Cristiano2132_model-track-cr:tests/test_placeholder.py`
+- **Line:** 3
+- **Effort:** 5min
+- **Tags:** confusing, suspicious, tests
+- **Link:** https://sonarcloud.io/project/issues?id=Cristiano2132_model-track-cr&open=AZ2KQ_ZvI4dBuagc4RCw
+
+---
+


### PR DESCRIPTION
This PR changes the behavior of the `sonar_github_issues.py` script. Previously, it was configured to automatically open GitHub issues for every problem reported by SonarCloud. To prevent cluttering the issue board and avoid unnecessary API calls, the script now exports a local Markdown report instead.

### 🛠️ What was done?

- **Markdown Export:** Added the `export_issues_to_markdown` function to save SonarCloud issues locally to `sonar_issues.md`.
- **Disabled GitHub Issues:** The logic that automatically created issues on GitHub was disabled (commented out) in the `main` flow.
- **Connection Validation:** Added a sanity check (`check_sonar_connection()`) at the start of the script to ensure communication with the SonarCloud API before processing.
- **Refactoring:** Improved readability and formatting of the `build_labels` and `create_issue` functions.
- **Linting:** Fixed import sorting and unnecessary f-strings using `ruff`.