### PR TITLE
Title docs: align README (EN/PT-BR) with the current package API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Each step is supported by a dedicated module that integrates naturally with the 
 
 ## 🏗️ Project Architecture
 
-`model-track-cr` follows a modular structure based on transformers compatible with the Scikit-Learn ecosystem. This ensures seamless integration into standard data science pipelines.
+`model-track-cr` is organized in **pandas-first** modules. Several classes inherit from `BaseTransformer` and expose `fit` / `transform`, but method signatures are **DataFrame-oriented** (for example, explicit column names and optional `columns` lists). That keeps the API explicit for modeling work; if you need a strict **scikit-learn `Pipeline`**, plan for thin wrapper steps that adapt arguments and return types.
 
 ```mermaid
 classDiagram
@@ -62,6 +62,14 @@ classDiagram
         }
     }
 
+    namespace binning {
+        class TreeBinner {
+            +bins
+            +fit(df, column, target)
+            +transform(df, column)
+        }
+    }
+
     namespace woe {
         class WoeCalculator {
             +mapping_: dict
@@ -70,8 +78,9 @@ classDiagram
         }
         class WoeStability {
             +date_col: str
+            +calc: WoeCalculator
             +calculate_stability_matrix(df, feature_col, target_col)
-            +generate_view(matrix, ax, title)
+            +generate_view(matrix, title, ax)
         }
         class CategoryMapper {
             +mapping_dict_: dict
@@ -79,89 +88,90 @@ classDiagram
         }
     }
 
+    BaseTransformer <|-- TreeBinner
     BaseTransformer <|-- WoeCalculator
     WoeStability *-- WoeCalculator : composes (self.calc)
-    WoeStability ..> CategoryMapper : provides data for
+    WoeStability ..> CategoryMapper : stability matrices
 ```
 
-### Key Components
+### Key components
 
-* **BaseTransformer**: An abstract base class that enforces the `fit`/`transform` contract, ensuring compatibility with Scikit-Learn pipelines.
-* **WoeCalculator**: Handles the Weight of Evidence (WoE) logic with Laplace Smoothing, essential for credit risk scorecards.
-* **WoeStability**: Orchestrates temporal stability analysis, generating WoE matrices across different time periods (safiras).
-* **CategoryMapper**: An optimized grouping engine that uses exhaustive search to minimize WoE inversions and maintain monotonic risk relationships.
+* **BaseTransformer**: Abstract `fit` / `transform` / `fit_transform` contract shared across several transformers.
+* **TreeBinner**: Supervised binning via `sklearn.tree.DecisionTreeClassifier` split thresholds.
+* **WoeCalculator**: WoE mappings with Laplace smoothing; `fit` / `transform` operate on one or more categorical columns.
+* **WoeStability** (`model_track.woe`): Per-period WoE matrices and plotting helpers; composes a `WoeCalculator`.
+* **CategoryMapper** (`model_track.woe`): Grouping suggestions over stability matrices (inversions / SSE cost).
+* **ProjectContext** (`model_track`): Serializable bag for bins, WoE maps, selected features, and free-form metadata (intended to grow with the library).
 
 ---
 
 
 ## 🧩 Core Modules Overview
 
-### 📊 1. Statistics & Diagnostics (`stats`)
+### 📊 1. Diagnostics and early statistics (`preprocessing`, `stats`)
 
-Provides tools for early-stage variable understanding:
+Use **`preprocessing`** for table-level audits and summaries, and **`stats`** for IV / association style metrics and selection helpers.
 
-- global summaries
-- missing value analysis
-- basic diagnostics to guide modeling decisions
+Example (variable audit summary):
 
-Example:
 ```python
-from model_track.stats import get_summary
+from model_track.preprocessing import DataAuditor
 
-summary = get_summary(df)
-````
+auditor = DataAuditor(target="target")
+summary = auditor.get_summary(df)
+```
+
+Example (IV-driven feature screening lives under `stats`):
+
+```python
+from model_track.stats import StatisticalSelector
+
+selector = StatisticalSelector()
+selector.fit(df, target="target", features=["feat_a", "feat_b"])
+df_selected = selector.transform(df)
+```
 
 This step typically informs:
 -	which variables to bin
 -	how to handle missing values
 -	potential stability risks
 
-📘 Detailed documentation is provided in a dedicated module guide.
-
 ---
 
-🪜 2. Binning & Categorization (binning)
+### 🪜 2. Binning & categorization (`binning`)
 
-Responsible for transforming continuous variables into interpretable and stable categories.
+Responsible for turning continuous inputs into ordered categories for WoE and stability workflows.
 
-Available strategies:
--	tree-based binning (TreeBinner)
--	quantile-based binning (QuantileBinner)
--	consistent application via BinApplier
+**Currently exported:** supervised **tree-based** binning (`TreeBinner`). Quantile binning and a dedicated “bin applier” helper are **not** in the package yet; they are listed under [Technical roadmap](#technical-roadmap).
 
 Example:
+
 ```python
-from model_track.binning import TreeBinner, BinApplier
+from model_track.binning import TreeBinner
 
 binner = TreeBinner(max_depth=2)
-binner.fit(df, feature="income", target="target")
-
-applier = BinApplier(df)
-df["income_cat"] = applier.apply("income", binner.bins_)
-````
-
-📘 Each binning strategy is documented in its own module reference.
+binner.fit(df, column="income", target="target")
+df["income_cat"] = binner.transform(df, column="income")
+```
 
 ---
 
-🧮 3. WOE & IV (woe)
+### 🧮 3. WoE and IV (`woe`, `stats`)
 
 Implements classic supervised modeling metrics:
--	WOE / IV tables
--	reusable WOE mappings
--	per-period analysis
+
+- WoE mappings and transformed columns via `WoeCalculator`
+- IV and related helpers via `model_track.stats` (for example `compute_iv`)
+- Per-period WoE paths via `WoeStability` (see section 4)
 
 Example:
 
 ```python
 from model_track.woe import WoeCalculator
 
-woe_table = WoeCalculator.compute_table(
-    df=df,
-    target_col="target",
-    feature_col="income_cat",
-    event_value=1,
-)
+calc = WoeCalculator()
+calc.fit(df, target="target", columns=["income_cat"])
+df_woe = calc.transform(df, columns=["income_cat"])
 ```
 
 These outputs are typically used for:
@@ -169,28 +179,24 @@ These outputs are typically used for:
 -	model interpretability
 -	direct input into linear models
 
-📘 Full API and examples are covered in the WOE module documentation.
-
 ---
 
-📈 4. Temporal Stability (stability)
+### 📈 4. Temporal WoE stability (`model_track.woe`)
 
-Tools to assess whether variable behavior remains consistent over time.
-
-Currently available:
--	WOE stability by period
--	integrated visualizations
+Tools to assess whether category-level WoE stays consistent over time (e.g. by vintage or calendar period).
 
 Example:
 
 ```python
-from model_track.stability.woe import WoeStability
+from model_track.woe import WoeStability
 
-ws = WoeStability(df=df, date_col="period")
-ws.generate_view(
+ws = WoeStability(date_col="period")
+matrix = ws.calculate_stability_matrix(
+    df=df,
     feature_col="income_cat",
-    target_col="target"
+    target_col="target",
 )
+ws.generate_view(matrix, title="Income_cat WoE stability")
 ```
 
 This stage is essential for:
@@ -198,12 +204,9 @@ This stage is essential for:
 -	supporting production decisions
 -	monitoring deployed models
 
-📘 Stability concepts and metrics are documented in a dedicated guide.
-
-
 ---
 
-🚀 Installation
+## 🚀 Installation
 
 > Install in user mode:
 ```bash
@@ -215,7 +218,7 @@ The lib is available on https://pypi.org/project/model-track-cr/
 > Install in development mode:
 
 ```bash
-git clone https://github.com/YOUR_USER/model-track-cr.git
+git clone https://github.com/Cristiano2132/model-track-cr.git
 cd model-track-cr
 
 pip install -e .
@@ -225,7 +228,7 @@ poetry install
 ```
 ---
 
-## 🧪 Testing & Code Quality
+## 🧪 Testing and code quality
 
 Run tests: `make test`
 
@@ -235,41 +238,23 @@ HTML coverage report: `htmlcov/index.html`
 
 The project follows strict Test-Driven Development (TDD) and is backed by a robust **Testing Pyramid Strategy**. Every new feature must be accompanied by automated tests.
 
-📘 For an in-depth look at our testing tiers (Unit, Component, Integration, API/E2E), please refer to the [Testing Strategy Guide](documentation/TESTING_STRATEGY.md).
+For testing tiers (unit, statistical, integration, benchmarks), see the [Testing Strategy Guide](documentation/TESTING_STRATEGY.md). Contributor environment notes live in [`AGENTS.md`](AGENTS.md).
 
 ---
 
-🔄 Development Workflow & Project Management
+## Workflow and contributions
 
-This project uses:
--	Git Flow
--	GitHub Issues
--	GitHub Projects (Board)
-
-The full development workflow — including branch strategy, issue management, pull requests, CI behavior, and versioning — is documented in:
-
-📘 Project Management Guide with GitHub Projects + Git Flow￼
-
-This document is the official reference for contributors.
+This project uses Git Flow, GitHub Issues, and Pull Requests. Day-to-day commands, CI expectations, and local setup are summarized in [`AGENTS.md`](AGENTS.md).
 
 ---
 
-📚 Documentation Structure
+## Documentation in this repository
 
-Documentation is organized in three layers:
-	1.	Module-level documentation
-Each core module (binning, stats, woe, stability, etc.) has its own detailed guide.
-	2.	API and technical references
-Focused on functions, classes, and parameters.
-	3.	End-to-end modeling guide
-A complete, real-world example demonstrating how all modules are used together
-in a full modeling workflow.
-
-The end-to-end guide is intended to be the final and most integrative document.
+Right now, the main narrative lives in this README (EN / PT-BR) plus the testing strategy linked above. Docstrings in `src/model_track` are the API reference. Deeper per-module guides and an end-to-end modeling walkthrough can be added as the surface area grows.
 
 ---
 
-🧠 When Should You Use This Library?
+## When should you use this library?
 
 This project is a good fit if you want to:
 -	standardize modeling workflows across teams
@@ -280,16 +265,17 @@ This project is a good fit if you want to:
 
 ---
 
-📍 Technical Roadmap
--	automated PSI computation
--	feature selection based on stability
--	pipeline integrations
--	additional drift metrics
--	improved visualization utilities
+## Technical roadmap
+
+- Quantile-based binning and helpers to apply saved bins consistently across tables
+- Automated PSI and additional drift metrics
+- Feature selection informed by stability matrices
+- Clearer optional adapters for scikit-learn `Pipeline` users
+- Richer monitoring and visualization utilities
 
 ---
 
-📝 License
+## License
 
 MIT
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -47,9 +47,9 @@ Cada etapa é suportada por um módulo dedicado que se integra naturalmente com 
 
 ---
 
-## 🏗️ Arquitetura do Projeto
+## 🏗️ Arquitetura do projeto
 
-O `model-track-cr` segue uma estrutura modular baseada em transformadores compatíveis com o ecossistema Scikit-Learn. Isso garante uma integração perfeita em pipelines padrão de ciência de dados.
+O `model-track-cr` está organizado em módulos **pandas-first**. Várias classes herdam de `BaseTransformer` e expõem `fit` / `transform`, mas as assinaturas são **orientadas a DataFrame** (por exemplo, nomes explícitos de colunas e listas opcionais `columns`). Isso deixa a API explícita para modelagem; se você precisar de um **`Pipeline` estrito do scikit-learn**, o caminho natural é usar adaptadores finos que convertam argumentos e tipos de retorno.
 
 ```mermaid
 classDiagram
@@ -61,6 +61,14 @@ classDiagram
         }
     }
 
+    namespace binning {
+        class TreeBinner {
+            +bins
+            +fit(df, column, target)
+            +transform(df, column)
+        }
+    }
+
     namespace woe {
         class WoeCalculator {
             +mapping_: dict
@@ -69,8 +77,9 @@ classDiagram
         }
         class WoeStability {
             +date_col: str
+            +calc: WoeCalculator
             +calculate_stability_matrix(df, feature_col, target_col)
-            +generate_view(matrix, ax, title)
+            +generate_view(matrix, title, ax)
         }
         class CategoryMapper {
             +mapping_dict_: dict
@@ -78,35 +87,46 @@ classDiagram
         }
     }
 
+    BaseTransformer <|-- TreeBinner
     BaseTransformer <|-- WoeCalculator
     WoeStability *-- WoeCalculator : compõe (self.calc)
-    WoeStability ..> CategoryMapper : fornece dados para
+    WoeStability ..> CategoryMapper : matrizes de estabilidade
 ```
 
-### Componentes Principais
+### Componentes principais
 
-* **BaseTransformer**: Classe base abstrata que impõe o contrato `fit`/`transform`, garantindo compatibilidade com pipelines Scikit-Learn.
-* **WoeCalculator**: Lida com a lógica de Weight of Evidence (WoE) utilizando Laplace Smoothing, essencial para scorecards de risco de crédito.
-* **WoeStability**: Orquestra a análise de estabilidade temporal, gerando matrizes de WoE em diferentes períodos de tempo (safras).
-* **CategoryMapper**: Um motor otimizado de agrupamento que usa busca exaustiva para minimizar inversões de WoE e manter relações de risco monotônicas.
+* **BaseTransformer**: contrato abstrato `fit` / `transform` / `fit_transform` compartilhado por vários transformadores.
+* **TreeBinner**: binning supervisionado com limiares de `sklearn.tree.DecisionTreeClassifier`.
+* **WoeCalculator**: mapeamentos WoE com suavização de Laplace; `fit` / `transform` em uma ou mais colunas categóricas.
+* **WoeStability** (`model_track.woe`): matrizes de WoE por período e gráficos; compõe um `WoeCalculator`.
+* **CategoryMapper** (`model_track.woe`): sugestão de agrupamentos sobre matrizes de estabilidade (custo de inversões / SSE).
+* **ProjectContext** (`model_track`): objeto serializável para bins, mapas WoE, features selecionadas e metadados livres (previsto para crescer com a biblioteca).
 
 ---
 
 ## 🧩 Visão Geral dos Módulos Core
 
-### 📊 1. Estatísticas & Diagnósticos (`stats`)
+### 📊 1. Diagnósticos e estatísticas iniciais (`preprocessing`, `stats`)
 
-Fornece ferramentas para compreensão de variáveis em estágio inicial:
+Use **`preprocessing`** para auditorias e resumos ao nível da tabela, e **`stats`** para IV / associação e auxiliares de seleção.
 
-- resumos globais
-- análise de valores ausentes
-- diagnósticos básicos para orientar decisões de modelagem
+Exemplo (resumo de auditoria de variáveis):
 
-Exemplo:
 ```python
-from model_track.stats import get_summary
+from model_track.preprocessing import DataAuditor
 
-summary = get_summary(df)
+auditor = DataAuditor(target="target")
+summary = auditor.get_summary(df)
+```
+
+Exemplo (seleção guiada por IV em `stats`):
+
+```python
+from model_track.stats import StatisticalSelector
+
+selector = StatisticalSelector()
+selector.fit(df, target="target", features=["feat_a", "feat_b"])
+df_selected = selector.transform(df)
 ```
 
 Este passo geralmente informa:
@@ -114,52 +134,42 @@ Este passo geralmente informa:
 - como tratar valores ausentes
 - potenciais riscos de estabilidade
 
-📘 Documentação detalhada é fornecida em um guia de módulo dedicado.
-
 ---
 
-### 🪜 2. Binning & Categorização (`binning`)
+### 🪜 2. Binning e categorização (`binning`)
 
-Responsável por transformar variáveis contínuas em categorias estáveis e interpretáveis.
+Transforma entradas contínuas em categorias ordenadas para fluxos de WoE e estabilidade.
 
-Estratégias disponíveis:
-- agrupamento baseado em árvores (`TreeBinner`)
-- agrupamento baseado em quantis (`QuantileBinner`)
-- aplicação consistente via `BinApplier`
+**Exportado hoje:** binning supervisionado baseado em **árvore** (`TreeBinner`). Binning por quantis e um helper dedicado de “aplicar bins” **ainda não** estão no pacote; constam no roadmap técnico ao final deste documento.
 
 Exemplo:
+
 ```python
-from model_track.binning import TreeBinner, BinApplier
+from model_track.binning import TreeBinner
 
 binner = TreeBinner(max_depth=2)
-binner.fit(df, feature="income", target="target")
-
-applier = BinApplier(df)
-df["income_cat"] = applier.apply("income", binner.bins_)
+binner.fit(df, column="income", target="target")
+df["income_cat"] = binner.transform(df, column="income")
 ```
-
-📘 Cada estratégia de binning está documentada em sua própria referência de módulo.
 
 ---
 
-### 🧮 3. WOE & IV (`woe`)
+### 🧮 3. WoE e IV (`woe`, `stats`)
 
-Implementa métricas clássicas de modelagem supervisionada:
-- tabelas WOE / IV
-- mapeamentos WOE reutilizáveis
-- análise por período
+Métricas clássicas de modelagem supervisionada:
+
+- mapeamentos WoE e colunas transformadas via `WoeCalculator`
+- IV e funções relacionadas em `model_track.stats` (por exemplo `compute_iv`)
+- WoE por período via `WoeStability` (ver seção 4)
 
 Exemplo:
 
 ```python
 from model_track.woe import WoeCalculator
 
-woe_table = WoeCalculator.compute_table(
-    df=df,
-    target_col="target",
-    feature_col="income_cat",
-    event_value=1,
-)
+calc = WoeCalculator()
+calc.fit(df, target="target", columns=["income_cat"])
+df_woe = calc.transform(df, columns=["income_cat"])
 ```
 
 Essas saídas geralmente são usadas para:
@@ -167,36 +177,30 @@ Essas saídas geralmente são usadas para:
 - interpretabilidade de modelo
 - entrada direta para modelos lineares
 
-📘 A API completa e exemplos estão cobertos na documentação do módulo WOE.
-
 ---
 
-### 📈 4. Estabilidade Temporal (`stability`)
+### 📈 4. Estabilidade temporal de WoE (`model_track.woe`)
 
-Ferramentas para avaliar se o comportamento de uma variável permanece consistente ao longo do tempo.
-
-Atualmente disponíveis:
-- estabilidade de WOE por período
-- visualizações integradas
+Avalia se o WoE por categoria permanece coerente no tempo (por exemplo por safra ou período).
 
 Exemplo:
 
 ```python
-from model_track.stability.woe import WoeStability
+from model_track.woe import WoeStability
 
-ws = WoeStability(df=df, date_col="period")
-ws.generate_view(
+ws = WoeStability(date_col="period")
+matrix = ws.calculate_stability_matrix(
+    df=df,
     feature_col="income_cat",
-    target_col="target"
+    target_col="target",
 )
+ws.generate_view(matrix, title="Estabilidade WoE — income_cat")
 ```
 
 Esta etapa é essencial para:
 - validar a robustez do modelo
 - apoiar decisões de produção
 - monitorar modelos implantados
-
-📘 Os conceitos e métricas de estabilidade estão documentados em um guia dedicado.
 
 ---
 
@@ -211,7 +215,7 @@ A biblioteca está disponível no PyPI: https://pypi.org/project/model-track-cr/
 > Instalar no modo desenvolvimento:
 
 ```bash
-git clone https://github.com/YOUR_USER/model-track-cr.git
+git clone https://github.com/Cristiano2132/model-track-cr.git
 cd model-track-cr
 
 pip install -e .
@@ -222,7 +226,7 @@ poetry install
 
 ---
 
-## 🧪 Qualidade de Código & Testes
+## 🧪 Testes e qualidade de código
 
 Rodar testes: `make test`
 
@@ -230,42 +234,25 @@ Rodar testes com coverage: `make cov`
 
 Relatório de coverage HTML: `htmlcov/index.html`
 
-O projeto segue um rigoroso Test-Driven Development (TDD) e é apoiado por uma robusta **Estratégia de Pirâmide de Testes**. Toda nova funcionalidade deve ser acompanhada de testes automatizados.
+O projeto segue Test-Driven Development (TDD) e uma **pirâmide de testes** (unitário, estatístico com Hipóteses, integração, benchmarks). Toda nova funcionalidade deve vir com testes automatizados.
 
-📘 Para uma análise detalhada dos nossos níveis de teste (Unitário, Componente, Integração, API/E2E), consulte o [Guia de Estratégia de Testes](documentation/TESTING_STRATEGY.pt-br.md).
-
----
-
-## 🔄 Fluxo de Desenvolvimento & Gestão de Projetos
-
-Este projeto usa:
-- Git Flow
-- GitHub Issues
-- GitHub Projects (Board)
-
-Todo o fluxo de desenvolvimento — incluindo estratégia de branch, gestão de issues, pull requests, comportamento de CI e versionamento — está documentado em:
-
-📘 Guia de Gestão de Projetos com GitHub Projects + Git Flow
-
-Este documento é a referência oficial para contribuidores.
+Para detalhes dos níveis, veja o [Guia de estratégia de testes](documentation/TESTING_STRATEGY.pt-br.md). Comandos locais e CI estão resumidos em [`AGENTS.md`](AGENTS.md).
 
 ---
 
-## 📚 Estrutura da Documentação
+## Fluxo de trabalho e contribuições
 
-A documentação é organizada em três camadas:
-1. **Documentação a nível de módulo**
-   Cada módulo core (binning, stats, woe, stability, etc.) possui seu próprio guia detalhado.
-2. **API e referências técnicas**
-   Focado em funções, classes e parâmetros.
-3. **Guia de modelagem ponta-a-ponta (End-to-End)**
-   Um exemplo real e completo demonstrando como todos os módulos são utilizados em conjunto em um fluxo integral de modelagem.
-
-O guia end-to-end tem como objetivo ser o documento final e mais integrativo.
+O projeto usa Git Flow, GitHub Issues e Pull Requests. Orientações de ambiente e CI estão em [`AGENTS.md`](AGENTS.md).
 
 ---
 
-## 🧠 Quando você deve usar esta biblioteca?
+## Documentação neste repositório
+
+Hoje a narrativa principal está neste README (EN / PT-BR) e no guia de testes acima. As docstrings em `src/model_track` funcionam como referência de API. Guias por módulo e um walkthrough ponta a ponta podem ser adicionados conforme a superfície da biblioteca crescer.
+
+---
+
+## Quando usar esta biblioteca?
 
 Este projeto é uma ótima escolha se você deseja:
 - padronizar fluxos de modelagem entre equipes
@@ -276,12 +263,13 @@ Este projeto é uma ótima escolha se você deseja:
 
 ---
 
-## 📍 Roadmap Técnico
-- cálculo automatizado de PSI
-- seleção de features baseada em estabilidade
-- integrações de pipeline
-- métricas adicionais de drift
-- utilitários de visualização aprimorados
+## Roadmap técnico
+
+- Binning por quantis e helpers para aplicar bins salvos de forma consistente entre bases
+- PSI automatizado e métricas adicionais de drift
+- Seleção de features informada por matrizes de estabilidade
+- Adaptadores opcionais mais claros para usuários de `Pipeline` do scikit-learn
+- Utilitários de monitoramento e visualização mais ricos
 
 ---
 


### PR DESCRIPTION
## Goal

Update `README.md` and `README.pt-br.md` so they match what is actually implemented and exported today, and remove examples that reference non-existent APIs or modules.

## Changes

- **Architecture:** Mermaid diagram and component list aligned with `BaseTransformer`, `TreeBinner`, `WoeCalculator`, `WoeStability`, `CategoryMapper`, and `ProjectContext`.
- **Positioning:** Clarified **pandas-first** transformers and an honest note about strict `sklearn.pipeline.Pipeline` usage (thin adapters when needed).
- **Diagnostics:** Example uses `DataAuditor.get_summary` from `preprocessing` (not `get_summary` on `stats`).
- **Selection / IV:** Example uses `StatisticalSelector` from `stats`; mentions `compute_iv` where relevant.
- **Binning:** Documents only `TreeBinner` with the `column=` parameter; `QuantileBinner` / `BinApplier` called out as roadmap until shipped.
- **WoE:** `fit` / `transform` examples instead of legacy APIs such as `compute_table`.
- **Stability:** Correct imports and usage for `model_track.woe.WoeStability`, `calculate_stability_matrix`, and `generate_view`.
- **Docs in this repo:** Narrative matches what exists today (README pair, `documentation/TESTING_STRATEGY*`, `AGENTS.md`, and docstrings in `src/model_track`).
- **Clone URL:** Real repository URL instead of a placeholder.
- **Roadmap:** Quantile binning, consistent bin application, PSI/drift, pipeline adapters, richer monitoring/visuals.

## How to review

- Skim README code blocks for correct imports and signatures.
- Check links to `AGENTS.md` and the testing strategy guides.

## Notes

- Documentation-only change; no production code paths modified.