### PR TITLE
refactor(core): move heavy ML dependencies to optional tuning extra #39

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        install-type: ["base", "tuning"]
 
     steps:
       - name: Checkout code
@@ -41,7 +42,12 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install --no-interaction --with dev
+        run: |
+          if [ "${{ matrix.install-type }}" = "tuning" ]; then
+            poetry install --no-interaction --with dev --all-extras
+          else
+            poetry install --no-interaction --with dev
+          fi
 
       - name: Run Ruff
         run: poetry run ruff check .

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ This stage is essential for:
 > Install in user mode:
 ```bash
 pip install model-track-cr
+
+# Or with heavy ML dependencies (LightGBM, etc.):
+pip install "model-track-cr[tuning]"
 ```
 The lib is available on https://pypi.org/project/model-track-cr/
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -209,6 +209,9 @@ Esta etapa é essencial para:
 > Instalar no modo usuário:
 ```bash
 pip install model-track-cr
+
+# Ou com dependências pesadas de ML (LightGBM, etc.):
+pip install "model-track-cr[tuning]"
 ```
 A biblioteca está disponível no PyPI: https://pypi.org/project/model-track-cr/
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,9 +58,10 @@ yaml = ["PyYAML"]
 name = "bayesian-optimization"
 version = "1.4.3"
 description = "Bayesian Optimization package"
-optional = false
+optional = true
 python-versions = ">= 3.7"
 groups = ["main"]
+markers = "extra == \"tuning\""
 files = [
     {file = "bayesian-optimization-1.4.3.tar.gz", hash = "sha256:f9a448e1b52d961301cbc953ce4199709f6c26b1c88994c9b4dadb7752a64550"},
     {file = "bayesian_optimization-1.4.3-py3-none-any.whl", hash = "sha256:2719272d5825f1ba7d7609f3b1c1fdca13eba1b7ad52a5ca2e62f34154ecae28"},
@@ -384,7 +385,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
+markers = {main = "extra == \"tuning\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
 name = "comm"
@@ -1488,9 +1489,10 @@ dev = ["Sphinx (>=5.0.2)", "doc8 (>=0.11.2)", "pytest (>=7.0.1)", "pytest-xdist 
 name = "lightgbm"
 version = "4.6.0"
 description = "LightGBM Python-package"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"tuning\""
 files = [
     {file = "lightgbm-4.6.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:b7a393de8a334d5c8e490df91270f0763f83f959574d504c7ccb9eee4aef70ed"},
     {file = "lightgbm-4.6.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:2dafd98d4e02b844ceb0b61450a660681076b1ea6c7adb8c566dfd66832aafad"},
@@ -3290,7 +3292,10 @@ files = [
     {file = "wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"},
 ]
 
+[extras]
+tuning = ["bayesian-optimization", "lightgbm"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "27f9499613823e0aaa87b91a0d7e35dad1d426ab565baf3d3ca62fda4575c90f"
+content-hash = "95c7d09cbcfef0b7e8d79f929e953457f5c6e066577d5ac86939b162bb081396"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,14 @@ dependencies = [
     "scikit-learn>=1.2,<2.0",
     "matplotlib>=3.7,<4.0",
     "seaborn>=0.12,<0.14",
-    "bayesian-optimization==1.4.3",
-    "lightgbm>=4.3.0,<5.0.0",
     "joblib>=1.3.0",
     "pygments (>=2.20.0,<3.0.0)"
+]
+
+[project.optional-dependencies]
+tuning = [
+    "lightgbm>=4.3.0,<5.0.0",
+    "bayesian-optimization==1.4.3",
 ]
 
 [tool.poetry]


### PR DESCRIPTION
## Summary
- **Problem**: `lightgbm` and `bayesian-optimization` are heavy dependencies that were previously required for all users, even those only needing core statistical utilities.
- **Need**: Making these dependencies optional reduces the base installation size and allows for faster deployments in environments where tuning is not required.

## Changes
- **Dependency Refactoring**: Moved `lightgbm` and `bayesian-optimization` from `[project.dependencies]` to `[project.optional-dependencies]` under the `tuning` extra.
- **Lock Management**: Updated `poetry.lock` to reflect the new dependency structure.
- **Documentation**: Updated `README.md` and `README.pt-br.md` with instructions on how to install the library with tuning support (`pip install "model-track-cr[tuning]"`).
- **CI/CD Enhancement**: Updated the GitHub Actions matrix to test both a "base" installation and a "tuning" installation across all supported Python versions.

## Test plan
- [x] **Local Validation**: Ran `make test`. All 49 tests passed (100% coverage).
- [x] **Security Check**: `poetry run pip-audit` confirmed no new vulnerabilities.
- [ ] **CI Validation**: New matrix will verify stability in both installation modes.

## Risk & rollback
- **Risk level**: Low. These libraries were not yet imported in the `src/` core code.
- **Rollback**: Revert `pyproject.toml` and `poetry.lock` changes.

## Related
- **Issue**: #39
- **Milestone**: M1 - Foundation Fixes

## Checklist
- [x] Title follows `type(scope): short description`
- [x] Linked issues are referenced (#39)
- [x] Scope is small and focused
- [x] Tests/Docs updated