### PR TITLE
[FEAT] #52 — Implement OvRWoeAdapter for multiclass WoE via One-vs-Rest

### DIFF
--- a/src/model_track/woe/__init__.py
+++ b/src/model_track/woe/__init__.py
@@ -3,7 +3,7 @@ WoE (Weight of Evidence) module for model-track.
 Tools for WoE calculation, stability analysis, and category mapping.
 
 Example:
-    >>> from model_track.woe import WoeCalculator, WoeStability
+    >>> from model_track.woe import WoeCalculator, WoeStability, OvRWoeAdapter
     >>> # Calculate WoE
     >>> calc = WoeCalculator()
     >>> calc.fit(df, target="target", columns=["category_col"])
@@ -14,6 +14,7 @@ Example:
 """
 
 from model_track.woe.calculator import WoeCalculator
+from model_track.woe.ovr_adapter import OvRWoeAdapter
 from model_track.woe.stability import CategoryMapper, WoeStability
 
-__all__ = ["WoeCalculator", "WoeStability", "CategoryMapper"]
+__all__ = ["WoeCalculator", "WoeStability", "CategoryMapper", "OvRWoeAdapter"]

--- a/src/model_track/woe/ovr_adapter.py
+++ b/src/model_track/woe/ovr_adapter.py
@@ -1,0 +1,253 @@
+"""
+OvRWoeAdapter — multiclass WoE via One-vs-Rest strategy.
+
+For multiclass targets, WoE and IV are binary metrics by design.
+This adapter trains one :class:`WoeCalculator` per class using the
+One-vs-Rest (OvR) strategy: for each class ``k``, observations
+belonging to ``k`` are treated as "events" (1) and all others as
+"non-events" (0).
+
+Example::
+
+    from model_track.woe import OvRWoeAdapter
+
+    adapter = OvRWoeAdapter(classes=["A", "B", "C"])
+    adapter.fit(df, target="risk_tier", columns=["income_cat", "region"])
+
+    # One WoE column per class per feature
+    df_woe = adapter.transform(df, columns=["income_cat", "region"], strategy="per_class")
+    # → income_cat_woe_A, income_cat_woe_B, income_cat_woe_C, region_woe_A, …
+
+    # Single WoE column per feature (class with highest IV wins)
+    df_woe = adapter.transform(df, columns=["income_cat", "region"], strategy="max_iv")
+    # → income_cat_woe, region_woe
+
+    iv_df = adapter.iv_summary()
+    # feature | iv_A | iv_B | iv_C | max_iv
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+from model_track.woe.calculator import WoeCalculator
+
+
+class OvRWoeAdapter:
+    """Multiclass WoE adapter using the One-vs-Rest (OvR) strategy.
+
+    Trains one :class:`WoeCalculator` per class and provides two
+    transform strategies:
+
+    * ``"per_class"`` — produces ``n_classes × n_features`` WoE columns
+      named ``{col}_woe_{k}``.
+    * ``"max_iv"`` — produces ``n_features`` WoE columns named ``{col}_woe``
+      using, for each feature, the class whose WoE mapping has the highest IV.
+
+    Args:
+        classes: Ordered list of class labels present in the target column.
+    """
+
+    def __init__(self, classes: list[str | int]) -> None:
+        if not classes:
+            raise ValueError("`classes` must not be empty.")
+        self.classes: list[str | int] = classes
+        self.calculators_: dict[str, WoeCalculator] = {}
+        self.iv_per_class_: dict[str, dict[str, float]] = {}
+        self._fitted_columns: list[str] = []
+        self._is_fitted: bool = False
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_iv(
+        df: pd.DataFrame,
+        binary_target: str,
+        feature: str,
+    ) -> float:
+        """Compute IV for a single feature against a binary target.
+
+        Uses the same Laplace-smoothed statistics as :class:`WoeCalculator`.
+
+        Args:
+            df: DataFrame containing *feature* and *binary_target* columns.
+            binary_target: Name of the binary (0/1) target column.
+            feature: Feature column name (already cast to ``str``).
+
+        Returns:
+            float: Information Value for the feature.
+        """
+        stats = df.groupby(feature, observed=True)[binary_target].agg(["count", "sum"])
+        stats.columns = pd.Index(["Total", "Bad"])
+        stats["Good"] = stats["Total"] - stats["Bad"]
+
+        total_bad: float = float(stats["Bad"].sum())
+        total_good: float = float(stats["Good"].sum())
+
+        perc_bad = (stats["Bad"] + 0.5) / (total_bad + 0.5)
+        perc_good = (stats["Good"] + 0.5) / (total_good + 0.5)
+
+        woe = np.log(perc_good / perc_bad)
+        iv_series = (perc_good - perc_bad) * woe
+        return float(iv_series.sum())
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def fit(
+        self,
+        df: pd.DataFrame,
+        target: str,
+        columns: list[str],
+    ) -> OvRWoeAdapter:
+        """Fit one WoeCalculator per class using OvR binary targets.
+
+        For each class ``k`` in :attr:`classes`, a temporary binary column
+        ``target_k`` is created (``1`` if ``df[target] == k``, else ``0``)
+        and a :class:`WoeCalculator` is trained on it.
+
+        IV is computed for every (class, feature) pair and stored in
+        :attr:`iv_per_class_`.
+
+        Args:
+            df: Training DataFrame.
+            target: Name of the multiclass target column.
+            columns: Feature columns to fit WoE on.
+
+        Returns:
+            OvRWoeAdapter: The fitted adapter (``self``).
+
+        Raises:
+            ValueError: If *columns* is empty or *target* not in *df*.
+        """
+        if not columns:
+            raise ValueError("`columns` must not be empty.")
+        if target not in df.columns:
+            raise ValueError(f"Target column '{target}' not found in DataFrame.")
+
+        self._fitted_columns = list(columns)
+        self.calculators_ = {}
+        self.iv_per_class_ = {}
+
+        for cls in self.classes:
+            key = str(cls)
+            binary_target = f"__ovr_target_{key}__"
+
+            # Build OvR binary view (no copy of the full DataFrame)
+            binary_col = (df[target] == cls).astype(int)
+            binary_series = pd.Series(binary_col.values, index=df.index, name=binary_target)
+
+            calc = WoeCalculator()
+            calc.fit(
+                df.assign(**{binary_target: binary_series}),
+                target=binary_target,
+                columns=columns,
+            )
+            self.calculators_[key] = calc
+
+            # Compute IV per feature for this class
+            iv_for_class: dict[str, float] = {}
+            tmp_df = df.assign(**{binary_target: binary_series})
+            for col in columns:
+                str_col = f"__str_{col}__"
+                tmp_df = tmp_df.assign(**{str_col: tmp_df[col].astype(str).fillna("N/A")})
+                iv_for_class[col] = self._compute_iv(tmp_df, binary_target, str_col)
+            self.iv_per_class_[key] = iv_for_class
+
+        self._is_fitted = True
+        return self
+
+    def transform(
+        self,
+        df: pd.DataFrame,
+        columns: list[str],
+        strategy: Literal["per_class", "max_iv"] = "per_class",
+    ) -> pd.DataFrame:
+        """Apply fitted WoE mappings to the DataFrame.
+
+        Args:
+            df: Input DataFrame (train or test).
+            columns: Feature columns to transform. Must be a subset of the
+                columns used during :meth:`fit`.
+            strategy: Output strategy.
+
+                * ``"per_class"`` — one ``{col}_woe_{k}`` column per
+                  class per feature.
+                * ``"max_iv"`` — one ``{col}_woe`` column per feature,
+                  using the class with the highest IV for that feature.
+
+        Returns:
+            pd.DataFrame: Copy of *df* with additional WoE columns.
+
+        Raises:
+            RuntimeError: If the adapter has not been fitted yet.
+            ValueError: If *strategy* is not recognised.
+        """
+        if not self._is_fitted:
+            raise RuntimeError("OvRWoeAdapter must be fitted before calling transform().")
+        if strategy not in ("per_class", "max_iv"):
+            raise ValueError(f"Unknown strategy '{strategy}'. Choose 'per_class' or 'max_iv'.")
+
+        df_out = df.copy()
+
+        if strategy == "per_class":
+            for cls in self.classes:
+                key = str(cls)
+                calc = self.calculators_[key]
+                # Transform produces {col}_woe columns; rename to {col}_woe_{k}
+                df_tmp = calc.transform(df_out, columns=columns)
+                for col in columns:
+                    src = f"{col}_woe"
+                    dst = f"{col}_woe_{key}"
+                    if src in df_tmp.columns:
+                        df_out[dst] = df_tmp[src]
+
+        else:  # "max_iv"
+            for col in columns:
+                # Pick the class with highest IV for this feature
+                best_cls = max(
+                    self.classes,
+                    key=lambda k: self.iv_per_class_.get(str(k), {}).get(col, 0.0),
+                )
+                key = str(best_cls)
+                calc = self.calculators_[key]
+                df_tmp = calc.transform(df_out, columns=[col])
+                src = f"{col}_woe"
+                if src in df_tmp.columns:
+                    df_out[src] = df_tmp[src]
+
+        return df_out
+
+    def iv_summary(self) -> pd.DataFrame:
+        """Return a DataFrame summarising IV per class per feature.
+
+        Returns:
+            pd.DataFrame: Index = feature name. Columns = ``iv_{k}`` for
+            each class, plus ``max_iv`` (maximum IV across all classes for
+            that feature).
+
+        Raises:
+            RuntimeError: If the adapter has not been fitted yet.
+        """
+        if not self._is_fitted:
+            raise RuntimeError("OvRWoeAdapter must be fitted before calling iv_summary().")
+
+        rows: dict[str, dict[str, float]] = {}
+        for col in self._fitted_columns:
+            row: dict[str, float] = {}
+            for cls in self.classes:
+                key = str(cls)
+                iv_val = self.iv_per_class_.get(key, {}).get(col, 0.0)
+                row[f"iv_{key}"] = iv_val
+            row["max_iv"] = max(row.values())
+            rows[col] = row
+
+        summary = pd.DataFrame.from_dict(rows, orient="index")
+        summary.index.name = "feature"
+        return summary

--- a/tests/integration/test_multiclass_pipeline.py
+++ b/tests/integration/test_multiclass_pipeline.py
@@ -1,0 +1,159 @@
+"""Integration test: OvRWoeAdapter end-to-end multiclass pipeline.
+
+Tests the full workflow:
+  synthetic data → OvRWoeAdapter.fit() → transform() → MulticlassEvaluator
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from model_track.evaluation import MulticlassEvaluator
+from model_track.woe import OvRWoeAdapter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_multiclass_dataset(
+    n: int = 500,
+    seed: int = 42,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Create a 3-class synthetic dataset and return (train, test) splits."""
+    rng = np.random.default_rng(seed)
+
+    # Target with 3 balanced classes
+    classes = ["low", "medium", "high"]
+    target = rng.choice(classes, size=n, p=[0.4, 0.35, 0.25])
+
+    # Categorical features with some correlation to target
+    income_map = {"low": ["A", "B"], "medium": ["B", "C"], "high": ["C", "D"]}
+    region_map = {
+        "low": ["north", "south"],
+        "medium": ["south", "east"],
+        "high": ["east", "north"],
+    }
+
+    income = np.array(
+        [rng.choice(income_map[t]) for t in target]  # type: ignore[index]
+    )
+    region = np.array(
+        [rng.choice(region_map[t]) for t in target]  # type: ignore[index]
+    )
+
+    df = pd.DataFrame({"target": target, "income": income, "region": region})
+
+    split = int(n * 0.7)
+    return df.iloc[:split].reset_index(drop=True), df.iloc[split:].reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_fit_transform_per_class_full_pipeline() -> None:
+    """Full pipeline: fit on train, transform train+test, no data leakage."""
+    train, test = make_multiclass_dataset()
+    classes = ["low", "medium", "high"]
+    columns = ["income", "region"]
+
+    adapter = OvRWoeAdapter(classes=classes)
+    adapter.fit(train, target="target", columns=columns)
+
+    train_woe = adapter.transform(train, columns=columns, strategy="per_class")
+    test_woe = adapter.transform(test, columns=columns, strategy="per_class")
+
+    # All per-class WoE columns are present
+    expected_cols = [f"{c}_woe_{k}" for c in columns for k in classes]
+    for col in expected_cols:
+        assert col in train_woe.columns, f"Missing {col} in train"
+        assert col in test_woe.columns, f"Missing {col} in test"
+
+    # Original columns are unchanged (no leakage)
+    pd.testing.assert_series_equal(train_woe["target"], train["target"])
+    pd.testing.assert_series_equal(test_woe["target"], test["target"])
+
+    # No NaN in WoE columns
+    woe_train_cols = [c for c in train_woe.columns if "_woe_" in c]
+    assert train_woe[woe_train_cols].isna().sum().sum() == 0
+
+
+def test_fit_transform_max_iv_full_pipeline() -> None:
+    """max_iv strategy reduces dimensionality to n_features WoE columns."""
+    train, test = make_multiclass_dataset()
+    classes = ["low", "medium", "high"]
+    columns = ["income", "region"]
+
+    adapter = OvRWoeAdapter(classes=classes)
+    adapter.fit(train, target="target", columns=columns)
+
+    train_woe = adapter.transform(train, columns=columns, strategy="max_iv")
+    test_woe = adapter.transform(test, columns=columns, strategy="max_iv")
+
+    assert "income_woe" in train_woe.columns
+    assert "region_woe" in test_woe.columns
+
+    # Per-class columns should NOT be present
+    for k in classes:
+        assert f"income_woe_{k}" not in train_woe.columns
+
+
+def test_iv_summary_values_positive() -> None:
+    """IV values should be > 0 for features with real target correlation."""
+    train, _ = make_multiclass_dataset()
+    classes = ["low", "medium", "high"]
+
+    adapter = OvRWoeAdapter(classes=classes)
+    adapter.fit(train, target="target", columns=["income", "region"])
+
+    summary = adapter.iv_summary()
+
+    # max_iv must be positive for informative features
+    assert (summary["max_iv"] > 0).all(), f"Expected all max_iv > 0, got:\n{summary}"
+
+
+def test_pipeline_with_multiclass_evaluator() -> None:
+    """OvRWoeAdapter → dummy model → MulticlassEvaluator works end-to-end."""
+    train, test = make_multiclass_dataset(n=600)
+    classes = ["low", "medium", "high"]
+    columns = ["income", "region"]
+
+    # Fit WoE
+    adapter = OvRWoeAdapter(classes=classes)
+    adapter.fit(train, target="target", columns=columns)
+    test_woe = adapter.transform(test, columns=columns, strategy="per_class")
+
+    # Use WoE columns as features (simulate simple model with majority class)
+    y_true = test_woe["target"]
+    majority_class = train["target"].mode()[0]
+    y_pred = pd.Series([majority_class] * len(y_true), index=y_true.index)
+
+    evaluator = MulticlassEvaluator(average="macro")
+    metrics = evaluator.evaluate(y_true, y_pred=y_pred)
+
+    assert "accuracy" in metrics
+    assert "f1" in metrics
+    # Majority-class predictor should have accuracy around the majority-class proportion
+    assert 0.0 <= metrics["accuracy"] <= 1.0
+
+
+def test_transform_test_with_unseen_categories() -> None:
+    """Test set with unseen category values maps to WoE=0.0 (no error)."""
+    train, _ = make_multiclass_dataset()
+    classes = ["low", "medium", "high"]
+
+    adapter = OvRWoeAdapter(classes=classes)
+    adapter.fit(train, target="target", columns=["income"])
+
+    # Create test set with an unseen income category
+    df_test = pd.DataFrame({"target": ["low", "medium"], "income": ["UNSEEN", "A"]})
+    df_out = adapter.transform(df_test, columns=["income"], strategy="per_class")
+
+    # Unseen category → WoE = 0.0
+    assert df_out.loc[0, "income_woe_low"] == pytest.approx(0.0)
+    # Known category → real WoE value (should not be NaN)
+    assert not pd.isna(df_out.loc[1, "income_woe_low"])

--- a/tests/unit/woe/test_ovr_adapter.py
+++ b/tests/unit/woe/test_ovr_adapter.py
@@ -1,0 +1,243 @@
+"""Unit tests for OvRWoeAdapter."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from model_track.woe import OvRWoeAdapter
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def three_class_df() -> pd.DataFrame:
+    """Synthetic 3-class dataset with two categorical features."""
+    rng = np.random.default_rng(42)
+    n = 300
+    target = rng.choice(["low", "medium", "high"], size=n, p=[0.4, 0.35, 0.25])
+    income = rng.choice(["A", "B", "C"], size=n)
+    region = rng.choice(["north", "south", "east"], size=n)
+    return pd.DataFrame({"target": target, "income": income, "region": region})
+
+
+@pytest.fixture()
+def fitted_adapter(three_class_df: pd.DataFrame) -> OvRWoeAdapter:
+    adapter = OvRWoeAdapter(classes=["low", "medium", "high"])
+    adapter.fit(three_class_df, target="target", columns=["income", "region"])
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_empty_classes_raises() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        OvRWoeAdapter(classes=[])
+
+
+# ---------------------------------------------------------------------------
+# fit()
+# ---------------------------------------------------------------------------
+
+
+def test_fit_creates_one_calculator_per_class(
+    fitted_adapter: OvRWoeAdapter,
+) -> None:
+    assert set(fitted_adapter.calculators_.keys()) == {"low", "medium", "high"}
+
+
+def test_fit_iv_per_class_keys(fitted_adapter: OvRWoeAdapter) -> None:
+    assert set(fitted_adapter.iv_per_class_.keys()) == {"low", "medium", "high"}
+    for cls_iv in fitted_adapter.iv_per_class_.values():
+        assert set(cls_iv.keys()) == {"income", "region"}
+
+
+def test_fit_iv_non_negative(fitted_adapter: OvRWoeAdapter) -> None:
+    for cls_iv in fitted_adapter.iv_per_class_.values():
+        for iv_val in cls_iv.values():
+            assert iv_val >= 0.0
+
+
+def test_fit_missing_target_raises(three_class_df: pd.DataFrame) -> None:
+    adapter = OvRWoeAdapter(classes=["low", "medium", "high"])
+    with pytest.raises(ValueError, match="Target column"):
+        adapter.fit(three_class_df, target="nonexistent", columns=["income"])
+
+
+def test_fit_empty_columns_raises(three_class_df: pd.DataFrame) -> None:
+    adapter = OvRWoeAdapter(classes=["low", "medium", "high"])
+    with pytest.raises(ValueError, match="must not be empty"):
+        adapter.fit(three_class_df, target="target", columns=[])
+
+
+# ---------------------------------------------------------------------------
+# transform() — per_class
+# ---------------------------------------------------------------------------
+
+
+def test_transform_per_class_columns(
+    fitted_adapter: OvRWoeAdapter,
+    three_class_df: pd.DataFrame,
+) -> None:
+    df_out = fitted_adapter.transform(
+        three_class_df, columns=["income", "region"], strategy="per_class"
+    )
+    expected_cols = [
+        "income_woe_low",
+        "income_woe_medium",
+        "income_woe_high",
+        "region_woe_low",
+        "region_woe_medium",
+        "region_woe_high",
+    ]
+    for col in expected_cols:
+        assert col in df_out.columns, f"Missing column: {col}"
+
+
+def test_transform_per_class_no_nan(
+    fitted_adapter: OvRWoeAdapter,
+    three_class_df: pd.DataFrame,
+) -> None:
+    df_out = fitted_adapter.transform(
+        three_class_df, columns=["income", "region"], strategy="per_class"
+    )
+    woe_cols = [c for c in df_out.columns if "_woe_" in c]
+    assert df_out[woe_cols].isna().sum().sum() == 0
+
+
+def test_transform_per_class_original_cols_unchanged(
+    fitted_adapter: OvRWoeAdapter,
+    three_class_df: pd.DataFrame,
+) -> None:
+    df_out = fitted_adapter.transform(
+        three_class_df, columns=["income", "region"], strategy="per_class"
+    )
+    pd.testing.assert_series_equal(df_out["income"], three_class_df["income"])
+    pd.testing.assert_series_equal(df_out["region"], three_class_df["region"])
+
+
+# ---------------------------------------------------------------------------
+# transform() — max_iv
+# ---------------------------------------------------------------------------
+
+
+def test_transform_max_iv_columns(
+    fitted_adapter: OvRWoeAdapter,
+    three_class_df: pd.DataFrame,
+) -> None:
+    df_out = fitted_adapter.transform(
+        three_class_df, columns=["income", "region"], strategy="max_iv"
+    )
+    assert "income_woe" in df_out.columns
+    assert "region_woe" in df_out.columns
+    # Should NOT have per-class columns
+    assert "income_woe_low" not in df_out.columns
+
+
+def test_transform_max_iv_no_nan(
+    fitted_adapter: OvRWoeAdapter,
+    three_class_df: pd.DataFrame,
+) -> None:
+    df_out = fitted_adapter.transform(
+        three_class_df, columns=["income", "region"], strategy="max_iv"
+    )
+    woe_cols = ["income_woe", "region_woe"]
+    assert df_out[woe_cols].isna().sum().sum() == 0
+
+
+# ---------------------------------------------------------------------------
+# transform() — error cases
+# ---------------------------------------------------------------------------
+
+
+def test_unfitted_raises_on_transform(three_class_df: pd.DataFrame) -> None:
+    adapter = OvRWoeAdapter(classes=["low", "medium", "high"])
+    with pytest.raises(RuntimeError, match="fitted"):
+        adapter.transform(three_class_df, columns=["income"])
+
+
+def test_invalid_strategy_raises(
+    fitted_adapter: OvRWoeAdapter,
+    three_class_df: pd.DataFrame,
+) -> None:
+    with pytest.raises(ValueError, match="Unknown strategy"):
+        fitted_adapter.transform(
+            three_class_df,
+            columns=["income"],
+            strategy="unknown",  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unseen categories
+# ---------------------------------------------------------------------------
+
+
+def test_unseen_categories_fillna_zero(fitted_adapter: OvRWoeAdapter) -> None:
+    """Unseen category values should map to 0.0 (neutral WoE)."""
+    df_new = pd.DataFrame(
+        {
+            "target": ["low", "medium"],
+            "income": ["UNSEEN_CAT", "A"],
+            "region": ["north", "UNSEEN_REGION"],
+        }
+    )
+    df_out = fitted_adapter.transform(df_new, columns=["income", "region"], strategy="per_class")
+    # Rows with unseen categories should have 0.0 WoE
+    assert df_out.loc[0, "income_woe_low"] == pytest.approx(0.0)
+    assert df_out.loc[1, "region_woe_low"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# iv_summary()
+# ---------------------------------------------------------------------------
+
+
+def test_iv_summary_shape(fitted_adapter: OvRWoeAdapter) -> None:
+    summary = fitted_adapter.iv_summary()
+    assert summary.index.name == "feature"
+    assert list(summary.index) == ["income", "region"]
+    expected_cols = {"iv_low", "iv_medium", "iv_high", "max_iv"}
+    assert set(summary.columns) == expected_cols
+
+
+def test_iv_summary_max_iv_is_max(fitted_adapter: OvRWoeAdapter) -> None:
+    summary = fitted_adapter.iv_summary()
+    iv_cols = [c for c in summary.columns if c.startswith("iv_")]
+    for feature in summary.index:
+        computed_max = summary.loc[feature, iv_cols].max()
+        assert summary.loc[feature, "max_iv"] == pytest.approx(float(computed_max))
+
+
+def test_iv_summary_unfitted_raises() -> None:
+    adapter = OvRWoeAdapter(classes=["A", "B"])
+    with pytest.raises(RuntimeError, match="fitted"):
+        adapter.iv_summary()
+
+
+# ---------------------------------------------------------------------------
+# Two-class OvR is equivalent to binary WoE
+# ---------------------------------------------------------------------------
+
+
+def test_two_classes_per_class_produces_two_columns() -> None:
+    """With 2 classes, per_class strategy gives 2 WoE columns per feature."""
+    rng = np.random.default_rng(0)
+    n = 200
+    df = pd.DataFrame(
+        {
+            "target": rng.choice(["yes", "no"], size=n),
+            "cat": rng.choice(["X", "Y", "Z"], size=n),
+        }
+    )
+    adapter = OvRWoeAdapter(classes=["yes", "no"])
+    adapter.fit(df, target="target", columns=["cat"])
+    df_out = adapter.transform(df, columns=["cat"], strategy="per_class")
+    assert "cat_woe_yes" in df_out.columns
+    assert "cat_woe_no" in df_out.columns


### PR DESCRIPTION
## Summary

Implements `OvRWoeAdapter` — a multiclass extension of WoE/IV using the **One-vs-Rest (OvR)** strategy. For each class `k`, observations belonging to `k` are treated as events (1) and all others as non-events (0), enabling standard binary WoE computation per class.

Closes #52

---

## Changes

### New Files
- `src/model_track/woe/ovr_adapter.py` — `OvRWoeAdapter` class
- `tests/unit/woe/test_ovr_adapter.py` — 18 unit tests (100% coverage)
- `tests/integration/test_multiclass_pipeline.py` — 5 integration tests

### Modified Files
- `src/model_track/woe/__init__.py` — export `OvRWoeAdapter`

---

## API

```python
from model_track.woe import OvRWoeAdapter

adapter = OvRWoeAdapter(classes=["low", "medium", "high"])
adapter.fit(df_train, target="risk_tier", columns=["income_cat", "region"])

# Strategy 1: one WoE column per class per feature
df_woe = adapter.transform(df_test, columns=["income_cat", "region"], strategy="per_class")
# → income_cat_woe_low, income_cat_woe_medium, income_cat_woe_high, region_woe_low, ...

# Strategy 2: single WoE column (class with highest IV wins)
df_woe = adapter.transform(df_test, columns=["income_cat", "region"], strategy="max_iv")
# → income_cat_woe, region_woe

# IV summary
print(adapter.iv_summary())
# feature | iv_low | iv_medium | iv_high | max_iv
```

---

## Acceptance Criteria

- [x] `fit()` trains one `WoeCalculator` per class using OvR binary targets
- [x] `transform("per_class")` produces `n_classes × n_features` WoE columns
- [x] `transform("max_iv")` produces `n_features` WoE columns (highest-IV class wins)
- [x] `iv_summary()` returns DataFrame with IV per class per feature
- [x] Exported from `model_track.woe`
- [x] Unit tests with 3-class synthetic dataset (18 tests, 100% coverage)
- [x] Integration test: OvRWoeAdapter → MulticlassEvaluator flow
- [x] `mypy --strict` passes
- [x] `ruff check` passes
- [x] Global coverage: **99.73%** (199 tests passing)

---

## Test Results

```
199 passed in 12.99s
Total coverage: 99.73%  ✅ (required: 90%)
ovr_adapter.py: 100% ✅
mypy: no issues found ✅
ruff: no issues found ✅
```